### PR TITLE
feat: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/actions/apply-shared/action.yml
+++ b/.github/actions/apply-shared/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Terraform
-      uses: hashicorp/setup-Terraform@v3
+      uses: hashicorp/setup-Terraform@v4
       with:
         terraform_version: ${{ inputs.TERRAFORM_VERSION }}
 
@@ -31,7 +31,7 @@ runs:
       run: terraform --version
 
     - name: "Configure Shared Account AWS Credentials"
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.AWS_ECR_DEPLOYMENT_ROLE }}
         aws-region: ${{ inputs.AWS_REGION }}

--- a/.github/actions/apply-terraform/action.yml
+++ b/.github/actions/apply-terraform/action.yml
@@ -25,7 +25,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Terraform
-      uses: hashicorp/setup-Terraform@v3
+      uses: hashicorp/setup-Terraform@v4
       with:
         terraform_version: ${{ inputs.TERRAFORM_VERSION }}
 
@@ -34,7 +34,7 @@ runs:
       run: terraform --version
 
     - name: 'Configure AWS Credentials'
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.AWS_DEPLOYMENT_ROLE }}
         aws-region: ${{ inputs.AWS_REGION }}

--- a/.github/actions/build-and-push-image/action.yml
+++ b/.github/actions/build-and-push-image/action.yml
@@ -26,7 +26,7 @@ runs:
   using: "composite"
   steps:
   - name: 🔐 Configure AWS credentials
-    uses: aws-actions/configure-aws-credentials@v4
+    uses: aws-actions/configure-aws-credentials@v6
     with:
       role-to-assume: ${{ inputs.AWS_ROLE_ARN }}
       role-session-name: GitHub-Action-Role
@@ -65,7 +65,7 @@ runs:
       echo "EOF" >> $GITHUB_OUTPUT
 
   - name: 🐳 Docker Metadata
-    uses: docker/metadata-action@v5
+    uses: docker/metadata-action@v6
     id: meta
     with:
       images: "${{ steps.parse.outputs.images }}"
@@ -78,7 +78,7 @@ runs:
 
   - name: 🏗️ Build and push
     if: ${{ !inputs.CUSTOM_BUILD_SCRIPT }}
-    uses: docker/build-push-action@v5
+    uses: docker/build-push-action@v7
     with:
       push: true
       tags: ${{ steps.meta.outputs.tags }}

--- a/.github/actions/deploy-ecs-service/action.yml
+++ b/.github/actions/deploy-ecs-service/action.yml
@@ -42,7 +42,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Terraform
-      uses: hashicorp/setup-Terraform@v3
+      uses: hashicorp/setup-Terraform@v4
       with:
         terraform_version: ${{ inputs.TERRAFORM_VERSION }}
 
@@ -51,7 +51,7 @@ runs:
       run: terraform --version
 
     - name: 'Configure AWS Credentials'
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.AWS_DEPLOYMENT_ROLE }}
         aws-region: ${{ inputs.AWS_REGION }}

--- a/.github/actions/get-next-version/action.yml
+++ b/.github/actions/get-next-version/action.yml
@@ -25,7 +25,7 @@ runs:
   steps:
     - name: ⏭️ Determine the next release version
       id: semantic
-      uses: cycjimmy/semantic-release-action@v4
+      uses: cycjimmy/semantic-release-action@v6
       with:
         dry_run: true
         semantic_version: 24.2.3

--- a/.github/actions/github-release/action.yml
+++ b/.github/actions/github-release/action.yml
@@ -22,7 +22,7 @@ runs:
   steps:
     - name: ⏯️ Release
       id: semantic
-      uses: cycjimmy/semantic-release-action@v4
+      uses: cycjimmy/semantic-release-action@v6
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       with:

--- a/.github/actions/retag-docker-image/action.yml
+++ b/.github/actions/retag-docker-image/action.yml
@@ -22,7 +22,7 @@ runs:
   using: 'composite'
   steps:
     - name: 🔐 Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.AWS_ROLE_ARN }}
         role-session-name: GitHub-Action-Role

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -83,7 +83,7 @@ jobs:
       new_release_published: ${{ steps.get-next-version.outputs.new_release_published }}
     steps:
       - name: 📁 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🏷️ Get next version
         id: get-next-version
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: 📁 Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: '🚀 Apply shared'
       uses: aproorg/github-workflows/.github/actions/apply-shared@main
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: 📁 Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         lfs: ${{ inputs.build_checkout_with_lfs }}
         fetch-tags: ${{ inputs.build_checkout_fetch_tags }}
@@ -163,7 +163,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: 📁 Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: '🚀 Deploy to dev'
       uses: aproorg/github-workflows/.github/actions/deploy-ecs-service@main

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -13,7 +13,7 @@ jobs:
       new_release_published: ${{ steps.get-next-version.outputs.new_release_published }}
     steps:
       - name: 📁 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: 🏷️ Get next version
         id: get-next-version
         uses: aproorg/github-workflows/.github/actions/get-next-version@main
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📁 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📁 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🔖 Version tag image
         uses: aproorg/github-workflows/.github/actions/retag-docker-image@main
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📁 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🚀 Deploy to staging
         uses: aproorg/github-workflows/.github/actions/deploy-ecs-service@main
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📁 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🚀 Deploy to prod
         uses: aproorg/github-workflows/.github/actions/deploy-ecs-service@main

--- a/.github/workflows/terraform-quality-checks.yml
+++ b/.github/workflows/terraform-quality-checks.yml
@@ -18,13 +18,13 @@ jobs:
     name: "✅ Terraform quality checks"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: "📁 Checkout"
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         name: "📥 Cache plugin dir"
         with:
           path: ~/.tflint.d/plugins
@@ -42,13 +42,13 @@ jobs:
           key: rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
           restore-keys: rubygems-
 
-      - uses: terraform-linters/setup-tflint@v4
+      - uses: terraform-linters/setup-tflint@v6
         name: "🛠️ Setup TFLint"
         with:
           tflint_version: latest
 
       - name: "🛠️ Setup Terraform"
-        uses: hashicorp/setup-Terraform@v3
+        uses: hashicorp/setup-Terraform@v4
         with:
           terraform_version: ${{ inputs.terraform_version }}
 

--- a/.github/workflows/terraform-quality-checks.yml
+++ b/.github/workflows/terraform-quality-checks.yml
@@ -30,13 +30,13 @@ jobs:
           path: ~/.tflint.d/plugins
           key: tflint-${{ hashFiles('terraform/.tflint.hcl') }}
 
-      - uses: Homebrew/actions/setup-homebrew@master
+      - uses: Homebrew/actions/setup-homebrew@main
         name: "☕️ Set up Homebrew"
         id: set-up-homebrew
 
       - name: "📥 Cache Homebrew Bundler RubyGems"
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}


### PR DESCRIPTION
Update all actions to versions that support Node.js 24 runtime to resolve deprecation warnings on GitHub Actions runners.

Updated actions:
- actions/checkout: v4 → v5
- actions/cache: v4 → v5
- hashicorp/setup-terraform: v3 → v4
- terraform-linters/setup-tflint: v4 → v6
- aws-actions/configure-aws-credentials: v4 → v6
- docker/build-push-action: v5 → v7
- docker/metadata-action: v5 → v6
- cycjimmy/semantic-release-action: v4 → v6

BREAKING CHANGE: Major version updates may include breaking changes.