### PR TITLE
fix: pass cluster_name_prod to deploy-to-prod job

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -139,5 +139,5 @@ jobs:
           TERRAFORM_VERSION: ${{ inputs.terraform_version }}
           TERRAFORM_PATH: '${{ matrix.directory }}/terraform'
           SERVICE_NAME: ${{ matrix.name }}
-          CLUSTER_NAME: ${{ inputs.cluster_name_staging }}
+          CLUSTER_NAME: ${{ inputs.cluster_name_prod }}
           PRE_APPLIED_RESOURCES: ${{ inputs.pre_applied_resources }}


### PR DESCRIPTION
Fixes #18.

The `deploy-to-prod` job in `release-deploy.yml` was passing `cluster_name_staging` as `CLUSTER_NAME` instead of `cluster_name_prod`.

`CLUSTER_NAME` is only used by the `force-new-deployment` and `wait services-stable` steps in `deploy-ecs-service`, and those steps are currently skipped because `FORCE_NEW_DEPLOYMENT` defaults to `false`. The bug is latent — but enabling `FORCE_NEW_DEPLOYMENT` on a release deploy would target the staging cluster instead of prod.

One-line change: `cluster_name_staging` → `cluster_name_prod` on the `CLUSTER_NAME` input of the prod deployment step.